### PR TITLE
Suggestion - Added review comment

### DIFF
--- a/src/main/java/baseclass/com/baseclass.java
+++ b/src/main/java/baseclass/com/baseclass.java
@@ -22,6 +22,8 @@ public class baseclass {
             prop.load(fp);
             baseurl=prop.getProperty("testingurl");
             apiId=prop.getProperty("appid");
+            //We can set base URI here itself instead of test
+            //RestAssured.baseURI = prop.getProperty("testingurl");
 
         }catch (Exception e){
             e.printStackTrace();


### PR DESCRIPTION
We can keep all files in IConstant interface instead of file.
 Sample
public interface IConstant {	
		public static final String BASEURI="http://api.openweathermap.org";
}

and you can use directly
public class BaseClass implements IConstant {

	@BeforeSuite
	public void init() {
		// Set Base uri
		RestAssured.baseURI = BASEURI;
	}

}